### PR TITLE
Formalize the restriction transformation

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
           <h4>Restrictable tracks</h4>
           <p>
             We say that a {{MediaStreamTrack}} <var>T</var> is a
-            <dfn>restrictable MediaStreamTrack</dfn> if and only if it fulfils all of the following
+            <dfn>restrictable MediaStreamTrack</dfn> if and only if it fulfills all of the following
             conditions:
           </p>
           <ul>
@@ -173,7 +173,8 @@
             </li>
             <li>
               <p>
-                <var>E</var> has exactly one <a data-cite="css-break-4/#box-fragment">box fragment</a>.
+                <var>E</var> has exactly one
+                <a data-cite="css-break-4/#box-fragment">box fragment</a>.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -165,6 +165,15 @@
               <var>E</var> forms a <a data-cite="filter-effects-2/#backdrop-root">backdrop root</a>.
             </li>
           </ul>
+          <div class="note">
+            <p>To ensure these conditions hold, developers may use CSS such as the following snippet:</p>
+            <pre class="css">
+              #target {
+                isolation: isolate;     /* Forms a stacking context. */
+                transform-style: flat;  /* Flattened. */
+              }
+            </pre>
+          </div>
         </section>
         <h4>Valid restriction targets</h4>
         <p>

--- a/index.html
+++ b/index.html
@@ -235,9 +235,10 @@
       </p>
       <ol>
         <li>
-          If <var>cropTarget</var>.{{CropTarget/[[Element]]}} does not represent an element that's
-          in the DOM of either the captured [=top-level browsing context=] or one of its descendant
-          [=browsing contexts=], abort without producing a new frame.
+          If <var>cropTarget</var>.{{CropTarget/[[Element]]}} does not represent an {{Element}}
+          whose [=shadow-including root=] is a [=document=] within the captured surface's
+          [=top-level browsing context=] or a descendant [=browsing contexts=] thereof, abort
+          without producing a new frame.
         </li>
         <li>
           <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->

--- a/index.html
+++ b/index.html
@@ -243,10 +243,11 @@
         <li>
           <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->
           <!-- TODO(eladalon1983 / mfoltzgoogle): Specify the following "TODO reasons". -->
-          Because of TODO reasons, it is guaranteed that the <var>cropTarget</var>.[[\Element]] is
-          in its own stacking context. Ensure this stacking context is rendered in a separate pass,
-          clip the result to the intersection with the captured [=top-level browsing context=]'s
-          viewport, and deliver the frame to <var>videoTrack</var>.
+          Because of TODO reasons, it is guaranteed that the
+          <var>cropTarget</var>.{{CropTarget/[[Element]]}} is in its own stacking context. Ensure
+          this stacking context is rendered in a separate pass, clip the result to the intersection
+          with the captured [=top-level browsing context=]'s viewport, and deliver the frame to
+          <var>videoTrack</var>.
           <div class="note">
             It is outside of the scope of this specification whether the result of the separate
             render pass is used when producing a full representation of the captured surface for

--- a/index.html
+++ b/index.html
@@ -241,6 +241,12 @@
           without producing a new frame.
         </li>
         <li>
+          Let <var>intersection</var> be the intersection of
+          <var>cropTarget</var>.{{CropTarget/[[Element]]}}'s bounding box. and the captured
+          surface's [=top-level browsing context=]'s viewport.
+        </li>
+        <li>If <var>intersection</var> is empty, abort without producing a new frame.</li>
+        <li>
           <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->
           <!-- TODO(eladalon1983 / mfoltzgoogle): Specify the following "TODO reasons". -->
           Because of TODO reasons, it is guaranteed that the

--- a/index.html
+++ b/index.html
@@ -235,35 +235,31 @@
               execute the following algorithm:
             </p>
             <ol>
+              <li>
+                <p>
+                  If [=this=] is not a [=restrictable MediaStreamTrack=], return a {{Promise}}
+                  [=rejected=] with a new {{NotSupportedError}}.
+                </p>
+              </li>
               <li>Let <var>p</var> be a new {{Promise}}.</li>
               <li>
                 <p>Run the following steps in parallel:</p>
                 <ol>
                   <li>
+                    <p>Let <var>E</var> be <var>cropTarget</var>.{{CropTarget/[[Element]]}}.</p>
+                  </li>
+                  <li>
                     <p>
-                      If [=this=] is not a [=restrictable MediaStreamTrack=], return a {{Promise}}
-                      rejected with an error as follows:
+                      If <var>E</var> is not a [=valid restriction target=] for [=this=], return a
+                      {{Promise}} [=rejected=] with a new {{InvalidStateError}}.
                     </p>
-                    <ol>
-                      <li>
-                        If <var>T</var> is not a {{MediaStreamTrack}} returned inside of a
-                        {{MediaStream}} through a call to {{MediaDevices/getDisplayMedia()}}, or a
-                        clone of such a track, use {{NotSupportedError}}.
-                      </li>
-                      <li>
-                        If [=this=].<a data-cite="mediacapture-streams/#dfn-kind">kind</a> is not
-                        <a data-cite="mediacapture-streams/#dfn-video">"video"</a>, use
-                        {{NotSupportedError}}.
-                      </li>
-                      <li>Otherwise, use {{InvalidStateError}}.</li>
-                    </ol>
                   </li>
                   <li>
                     <p>
                       Update [=this=] video track's [=restriction-state=] according to
                       <var>cropTarget</var>:
                     </p>
-                    <ul>
+                    <ol>
                       <li>
                         If <var>cropTarget</var> is NOT {{undefined}}, the user agent MUST set
                         [=this=] video track's [=restriction-state=] to [=restricted=] and start
@@ -276,16 +272,16 @@
                         [=applying the restriction transformation=] to frames delivered to [=this=]
                         video track.
                       </li>
-                    </ul>
+                    </ol>
                   </li>
                   <li>
                     <p>
                       Call the track's state before this method invocation <var>PRE-STATE</var>, and
                       after this method invocation <var>POST-STATE</var>. The user agent MUST
-                      resolve <var>p</var> when it is guaranteed that no more frames cropped (or
-                      uncropped) according to <var>PRE-STATE</var> will be delivered to the
-                      application, and that any additional frames delivered to the application will
-                      therefore be cropped (or uncropped) according to either
+                      resolve <var>p</var> when it is guaranteed that no more frames [=restricted=]
+                      (or [=unrestricted=]) according to <var>PRE-STATE</var> will be delivered to
+                      the application, and that any additional frames delivered to the application
+                      will therefore be [=restricted=] (or [=unrestricted=]) according to either
                       <var>POST-STATE</var> or a later state.
                     </p>
                   </li>

--- a/index.html
+++ b/index.html
@@ -156,20 +156,34 @@
             only if it fulfils all of the following conditions:
           </p>
           <ul>
-            <li><var>E</var> forms a stacking context.</li>
             <li>
-              <var>E</var> is
-              <a data-cite="css-transforms-2#grouping-property-values">flattened in 3D.</a>
+              <p><var>E</var> forms a stacking context.</p>
             </li>
             <li>
-              <var>E</var> forms a <a data-cite="filter-effects-2/#backdrop-root">backdrop root</a>.
+              <p>
+                <var>E</var> is
+                <a data-cite="css-transforms-2#grouping-property-values">flattened in 3D.</a>
+              </p>
             </li>
             <li>
-              <var>E</var> is <a data-cite="css-images-4/#element-not-rendered">rendered</a>.
+              <p>
+                <var>E</var> forms a
+                <a data-cite="filter-effects-2/#backdrop-root">backdrop root</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                <var>E</var> only has one <a data-cite="css-break-4/#box-fragment">box fragment</a>.
+              </p>
+            </li>
+            <li>
+              <p><var>E</var> is <a data-cite="css-images-4/#element-not-rendered">rendered</a>.</p>
             </li>
           </ul>
           <div class="note">
-            <p>To ensure these conditions hold, developers may use CSS such as the following snippet:</p>
+            <p>
+              To ensure these conditions hold, developers may use CSS such as the following snippet:
+            </p>
             <pre class="css">
               #target {
                 isolation: isolate;     /* Forms a stacking context. */

--- a/index.html
+++ b/index.html
@@ -312,18 +312,9 @@
         </li>
         <li>If <var>intersection</var> is empty, abort without producing a new frame.</li>
         <li>
-          <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->
-          <!-- TODO(eladalon1983 / mfoltzgoogle): Specify the following "TODO reasons". -->
-          Because of TODO reasons, it is guaranteed that the
-          <var>E</var> is in its own stacking context. Ensure this stacking context is rendered in a
-          separate pass, clip the result to the intersection with the captured [=top-level browsing
-          context=]'s viewport, and deliver the frame to <var>videoTrack</var>.
-          <div class="note">
-            It is outside of the scope of this specification whether the result of the separate
-            render pass is used when producing a full representation of the captured surface for
-            display to the user, or for use in other captured tracks, or whether the captured
-            element is essentially rendered twice.
-          </div>
+          A corollary of previous steps is that <var>E</var> forms a stacking context. Produce and
+          deliver a frame consisting of an independent rendering of that stacking context, clipped
+          to <var>intersection</var>.
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -197,13 +197,13 @@
                         If <var>cropTarget</var> is NOT {{undefined}}, the user agent MUST set
                         [=this=] video track's [=restriction-state=] to [=restricted=] and start
                         [=applying the restriction transformation=] to all frames delivered to
-                        [=this=] video track.
+                        [=this=] video track with <var>cropTarget</var> as the target.
                       </li>
                       <li>
                         If <var>cropTarget</var> is set to {{undefined}}, the user agent MUST set
                         [=this=] video track's [=restriction-state=] to [=unrestricted=] and stop
-                        [=applying the restriction transformation=] to all frames delivered to
-                        [=this=] video track.
+                        [=applying the restriction transformation=] to frames delivered to [=this=]
+                        video track.
                       </li>
                     </ul>
                   </li>

--- a/index.html
+++ b/index.html
@@ -229,8 +229,9 @@
     <section id="applying-the-restriction-transformation">
       <h2><dfn>Applying the restriction transformation</dfn></h2>
       <p>
-        When it's time to produce <var>frame</var> for a video track <var>videoTrack</var> that is
-        [=restricted=] to a given target <var>cropTarget</var>, execute the following algorithm:
+        Whenever the user agent is about to produce a new <var>frame</var> for a video track
+        <var>videoTrack</var> that is [=restricted=] to a given target <var>cropTarget</var>, the
+        user agent MUST execute the following algorithm:
       </p>
       <ol>
         <li>

--- a/index.html
+++ b/index.html
@@ -124,6 +124,89 @@
     </section>
     <section id="restricting-a-track">
       <h2><dfn>Restriction Mechanism</dfn></h2>
+      <section>
+        <h3>Definitions</h3>
+        <section>
+          <h4>Restrictable tracks</h4>
+          <p>
+            We say that a {{MediaStreamTrack}} <var>T</var> is a
+            <dfn>restrictable MediaStreamTrack</dfn> if and only if it fulfils all of the following
+            conditions:
+          </p>
+          <ul>
+            <li>
+              <var>T</var> is either a {{MediaStreamTrack}} returned inside of a {{MediaStream}}
+              through a call to {{MediaDevices/getDisplayMedia()}}, or a clone of such a track.
+            </li>
+            <li>
+              <var>T</var>.<a data-cite="mediacapture-streams/#dfn-kind">kind</a> is
+              <a data-cite="mediacapture-streams/#dfn-video">"video"</a>.
+            </li>
+            <li>
+              <var>T</var>.<a data-cite="mediacapture-streams/#dfn-readystate">readyState</a> is
+              <a data-cite="mediacapture-streams/#idl-def-MediaStreamTrackState.live">"live"</a>.
+            </li>
+            <li><var>T</var> is not <a data-cite="mediacapture-region#dfn-cropped">cropped</a>.</li>
+          </ul>
+        </section>
+        <section>
+          <h4>Elements eligible for restriction</h4>
+          <p>
+            We say that an {{Element}} <var>E</var> is <dfn>eligible for restriction</dfn> if and
+            only if it fulfils all of the following conditions:
+          </p>
+          <ul>
+            <li><var>E</var> forms a stacking context.</li>
+            <li>
+              <var>E</var> is
+              <a data-cite="css-transforms-2#grouping-property-values">flattened in 3D.</a>
+            </li>
+            <li>
+              <var>E</var> forms a <a data-cite="filter-effects-2/#backdrop-root">backdrop root</a>.
+            </li>
+          </ul>
+        </section>
+        <h4>Valid restriction targets</h4>
+        <p>
+          We say that an {{Element}} <var>E</var> is a <dfn>valid restriction target</dfn> for a
+          {{MediaStreamTrack}} <var>T</var>, if and only if all of the following conditions hold:
+        </p>
+        <ul>
+          <li><var>T</var> is a [=restrictable MediaStreamTrack=].</li>
+          <li><var>E</var> is a [=eligible for restriction=].</li>
+          <li>
+            The [=top-level browsing context=] of the
+            <a data-cite="screen-capture/#dfn-display-surface">display surface</a>
+            that is the source of <var>T</var>, is <var>E</var>'s [=shadow-including root=].
+          </li>
+        </ul>
+        <div class="note">
+          <p>
+            Informally, this means that <var>T</var> is an active video track associated with
+            tab-capture, and <var>E</var> is an Element [=connected=] to the DOM in the captured
+            tab.
+          </p>
+          <p>
+            Note that whether an Element <var>E</var> is a [=valid restriction target=] for a
+            {{MediaStreamTrack}} <var>T</var> may change either before or after a capture starts, as
+            well as before or after restriction starts. Examples include:
+          </p>
+          <ul>
+            <li><var>T</var> is stopped programmatically.</li>
+            <li><var>T</var> is stopped by the user.</li>
+            <li>
+              <var>T</var>.<a data-cite="mediacapture-streams/#dfn-source-0">[[\Source]]</a> changes
+              due to user interaction with the user agent and/or operating system.
+            </li>
+            <li><var>E</var>'s set of CSS attributes changes.</li>
+          </ul>
+          <p>Invalidity before restriction starts will suppress restriction.</p>
+          <p>
+            Invalidity after restriction starts will suppress additional frames until validity is
+            restored.
+          </p>
+        </div>
+      </section>
       <section id="browser-capture-media-stream-track-extension">
         <h3>BrowserCaptureMediaStreamTrack extension</h3>
         <p>
@@ -146,7 +229,10 @@
           <dd>
             <p>
               Calls to this method instruct the user agent to start/stop restrict a video track.
-              When invoked, the user agent MUST execute the following algorithm:
+            </p>
+            <p>
+              When invoked with <var>cropTarget</var> as the first parameter, the user agent MUST
+              execute the following algorithm:
             </p>
             <ol>
               <li>Let <var>p</var> be a new {{Promise}}.</li>
@@ -155,37 +241,22 @@
                 <ol>
                   <li>
                     <p>
-                      If [=this=] track's
-                      <a data-cite="mediacapture-streams/#dfn-kind">kind</a>
-                      is not <a data-cite="mediacapture-streams/#dfn-video">"video"</a>, return a
-                      [=rejected=] {{Promise}} with {{NotSupportedError}}.
+                      If [=this=] is not a [=restrictable MediaStreamTrack=], return a {{Promise}}
+                      rejected with an error as follows:
                     </p>
-                  </li>
-                  <li>
-                    <p>
-                      If [=this=] track's
-                      <a data-cite="mediacapture-streams/#dfn-readystate">readyState</a>
-                      is not
-                      <a data-cite="mediacapture-streams/#idl-def-MediaStreamTrackState.live"
-                        >"live"</a
-                      >, return a [=rejected=] {{Promise}} with {{NotSupportedError}}. If the track
-                      is not live, return a rejected Promise with {{InvalidStateError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If [=this=] video track is
-                      <a data-cite="mediacapture-region#dfn-cropped">cropped</a>, return a
-                      {{Promise}} [=rejected=] with an {{InvalidStateError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If <var>cropTarget</var> is not {{undefined}}, but does not represent an
-                      {{Element}} within a [=browsing context=] whose [=top-level browsing context=]
-                      is the same as that which the track is capturing, the user agent MUST return a
-                      {{Promise}} [=rejected=] with an {{UnknownError}}.
-                    </p>
+                    <ol>
+                      <li>
+                        If <var>T</var> is not a {{MediaStreamTrack}} returned inside of a
+                        {{MediaStream}} through a call to {{MediaDevices/getDisplayMedia()}}, or a
+                        clone of such a track, use {{NotSupportedError}}.
+                      </li>
+                      <li>
+                        If [=this=].<a data-cite="mediacapture-streams/#dfn-kind">kind</a> is not
+                        <a data-cite="mediacapture-streams/#dfn-video">"video"</a>, use
+                        {{NotSupportedError}}.
+                      </li>
+                      <li>Otherwise, use {{InvalidStateError}}.</li>
+                    </ol>
                   </li>
                   <li>
                     <p>
@@ -230,30 +301,27 @@
       <h2><dfn>Applying the restriction transformation</dfn></h2>
       <p>
         Whenever the user agent is about to produce a new <var>frame</var> for a video track
-        <var>videoTrack</var> that is [=restricted=] to a given target <var>cropTarget</var>, the
-        user agent MUST execute the following algorithm:
+        <var>T</var> that is [=restricted=] to a given target <var>cropTarget</var>, the user agent
+        MUST execute the following algorithm:
       </p>
       <ol>
+        <li>Let <var>E</var> be <var>cropTarget</var>.{{CropTarget/[[Element]]}}.</li>
         <li>
-          If <var>cropTarget</var>.{{CropTarget/[[Element]]}} does not represent an {{Element}}
-          whose [=shadow-including root=] is a [=document=] within the captured surface's
-          [=top-level browsing context=] or a descendant [=browsing contexts=] thereof, abort
-          without producing a new frame.
+          If <var>E</var> is not a [=valid restriction target=] for <var>T</var>, abort without
+          producing a new frame.
         </li>
         <li>
-          Let <var>intersection</var> be the intersection of
-          <var>cropTarget</var>.{{CropTarget/[[Element]]}}'s bounding box. and the captured
-          surface's [=top-level browsing context=]'s viewport.
+          Let <var>intersection</var> be the intersection of <var>E</var>'s bounding box and the
+          captured surface's [=top-level browsing context=]'s viewport.
         </li>
         <li>If <var>intersection</var> is empty, abort without producing a new frame.</li>
         <li>
           <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->
           <!-- TODO(eladalon1983 / mfoltzgoogle): Specify the following "TODO reasons". -->
           Because of TODO reasons, it is guaranteed that the
-          <var>cropTarget</var>.{{CropTarget/[[Element]]}} is in its own stacking context. Ensure
-          this stacking context is rendered in a separate pass, clip the result to the intersection
-          with the captured [=top-level browsing context=]'s viewport, and deliver the frame to
-          <var>videoTrack</var>.
+          <var>E</var> is in its own stacking context. Ensure this stacking context is rendered in a
+          separate pass, clip the result to the intersection with the captured [=top-level browsing
+          context=]'s viewport, and deliver the frame to <var>videoTrack</var>.
           <div class="note">
             It is outside of the scope of this specification whether the result of the separate
             render pass is used when producing a full representation of the captured surface for

--- a/index.html
+++ b/index.html
@@ -196,22 +196,14 @@
                       <li>
                         If <var>cropTarget</var> is NOT {{undefined}}, the user agent MUST set
                         [=this=] video track's [=restriction-state=] to [=restricted=] and start
-                        restricting the track as follows:
-                        <ul>
-                          <li>
-                            Cropping the video to the intersection of the target-element's bounding
-                            box and the [=top-level browsing context=]'s viewport.
-                          </li>
-                          <li>
-                            Remove any pixels not derived from either the target-element or its
-                            descendants. (TODO: This point requires a less hand-wavy definition.)
-                          </li>
-                        </ul>
+                        [=applying the restriction transformation=] to all frames delivered to
+                        [=this=] video track.
                       </li>
                       <li>
                         If <var>cropTarget</var> is set to {{undefined}}, the user agent MUST set
                         [=this=] video track's [=restriction-state=] to [=unrestricted=] and stop
-                        restricting the track.
+                        [=applying the restriction transformation=] to all frames delivered to
+                        [=this=] video track.
                       </li>
                     </ul>
                   </li>
@@ -233,6 +225,35 @@
           </dd>
         </dl>
       </section>
+    </section>
+    <section id="applying-the-restriction-transformation">
+      <h2><dfn>Applying the restriction transformation</dfn></h2>
+      <p>
+        When it's time to produce <var>frame</var> for a video track <var>videoTrack</var> that is
+        [=restricted=] to a given target <var>cropTarget</var>, execute the following algorithm:
+      </p>
+      <ol>
+        <li>
+          <!-- TODO(eladalon1983): Fix linkability of slots in the mediacapture-region spec. -->
+          If <var>cropTarget</var>.[[\Element]] does not represent an element that's in the DOM of
+          either the captured [=top-level browsing context=] or one of its descendant [=browsing
+          contexts=], abort without producing a new frame.
+        </li>
+        <li>
+          <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->
+          <!-- TODO(eladalon1983 / mfoltzgoogle): Specify the following "TODO reasons". -->
+          Because of TODO reasons, it is guaranteed that the <var>cropTarget</var>.[[\Element]] is
+          in its own stacking context. Ensure this stacking context is rendered in a separate pass,
+          clip the result to the intersection with the captured [=top-level browsing context=]'s
+          viewport, and deliver the frame to <var>videoTrack</var>.
+          <div class="note">
+            It is outside of the scope of this specification whether the result of the separate
+            render pass is used when producing a full representation of the captured surface for
+            display to the user, or for use in other captured tracks, or whether the captured
+            element is essentially rendered twice.
+          </div>
+        </li>
+      </ol>
     </section>
     <section id="sample-code">
       <h2>Sample Code</h2>

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
             </li>
             <li>
               <p>
-                <var>E</var> only has one <a data-cite="css-break-4/#box-fragment">box fragment</a>.
+                <var>E</var> has exactly one <a data-cite="css-break-4/#box-fragment">box fragment</a>.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -234,10 +234,9 @@
       </p>
       <ol>
         <li>
-          <!-- TODO(eladalon1983): Fix linkability of slots in the mediacapture-region spec. -->
-          If <var>cropTarget</var>.[[\Element]] does not represent an element that's in the DOM of
-          either the captured [=top-level browsing context=] or one of its descendant [=browsing
-          contexts=], abort without producing a new frame.
+          If <var>cropTarget</var>.{{CropTarget/[[Element]]}} does not represent an element that's
+          in the DOM of either the captured [=top-level browsing context=] or one of its descendant
+          [=browsing contexts=], abort without producing a new frame.
         </li>
         <li>
           <!-- TODO(eladalon1983 / mfoltzgoogle): Improve spec language around rendering. -->

--- a/index.html
+++ b/index.html
@@ -164,6 +164,9 @@
             <li>
               <var>E</var> forms a <a data-cite="filter-effects-2/#backdrop-root">backdrop root</a>.
             </li>
+            <li>
+              <var>E</var> is <a data-cite="css-images-4/#element-not-rendered">rendered</a>.
+            </li>
           </ul>
           <div class="note">
             <p>To ensure these conditions hold, developers may use CSS such as the following snippet:</p>


### PR DESCRIPTION
This PR formalizes what restrictTo() does a bit better, but does not yet go all the way. (Hence some TODOs.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/element-capture/pull/13.html" title="Last updated on Jul 17, 2023, 7:43 PM UTC (d142590)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/element-capture/13/d510ec9...eladalon1983:d142590.html" title="Last updated on Jul 17, 2023, 7:43 PM UTC (d142590)">Diff</a>