### PR TITLE
Clarify restrictable tracks must be associated with tab-capture

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,15 @@
               through a call to {{MediaDevices/getDisplayMedia()}}, or a clone of such a track.
             </li>
             <li>
+              <var>T</var> is associated with a
+              <a data-cite="screen-capture/#dfn-browser">browser</a>
+              <a data-cite="screen-capture/#dfn-display-surface">dispaly surface</a>. (That is, if
+              <var>T</var>.{{MediaStreamTrack/getSettings()}} were called, it would have returned a
+              {{MediaTrackSettings}} dictionary containing the key
+              {{MediaTrackSettings/displaySurface}}
+              mapped to the value {{DisplayCaptureSurfaceType/"browser"}}.)
+            </li>
+            <li>
               <var>T</var>.<a data-cite="mediacapture-streams/#dfn-kind">kind</a> is
               <a data-cite="mediacapture-streams/#dfn-video">"video"</a>.
             </li>

--- a/index.html
+++ b/index.html
@@ -142,11 +142,11 @@
             <li>
               <var>T</var> is associated with a
               <a data-cite="screen-capture/#dfn-browser">browser</a>
-              <a data-cite="screen-capture/#dfn-display-surface">dispaly surface</a>. (That is, if
+              <a data-cite="screen-capture/#dfn-display-surface">display surface</a>. (That is, if
               <var>T</var>.{{MediaStreamTrack/getSettings()}} were called, it would have returned a
               {{MediaTrackSettings}} dictionary containing the key
-              {{MediaTrackSettings/displaySurface}}
-              mapped to the value {{DisplayCaptureSurfaceType/"browser"}}.)
+              {{MediaTrackSettings/displaySurface}} mapped to the value
+              {{DisplayCaptureSurfaceType/"browser"}}.)
             </li>
             <li>
               <var>T</var>.<a data-cite="mediacapture-streams/#dfn-kind">kind</a> is


### PR DESCRIPTION
Fixes #19.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 24, 2023, 8:46 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fscreen-share%2Felement-capture%2F879b29270e93afe857e35d5a71600122ea5c3f3e%2Findex.html%3FisPreview%3Dtrue)

```
Failed to launch the browser process!
[3266255:3266269:0724/084608.669571:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3266255:3266269:0724/084608.670113:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3266255:3266269:0724/084608.670147:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3266255:3266269:0724/084608.670175:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3266255:3266255:0724/084608.675318:ERROR:chrome_browser_cloud_management_controller.cc(162)] Cloud management controller initialization aborted as CBCM is not enabled.
[3266255:3266255:0724/084608.677180:ERROR:pref_service_builder_utils.cc(66)] Could not create README file.
[0724/084608.690210:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0724/084608.690469:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
[0724/084608.709603:ERROR:nacl_helper_linux.cc(355)] NaCl helper process running without a sandbox!
Most likely you need to configure your SUID sandbox correctly


TROUBLESHOOTING: https://pptr.dev/troubleshooting

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20screen-share/element-capture%2320.)._
</details>
