### PR TITLE
Remove the requirement of restriction-target-validity at restrictTo()

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,10 +339,8 @@
             </li>
             <li><var>E</var>'s set of CSS attributes changes.</li>
           </ul>
-          <p>Invalidity before restriction starts will suppress restriction.</p>
           <p>
-            Invalidity after restriction starts will suppress additional frames until validity is
-            restored.
+            Invalidity will suppress additional frames until validity is restored.
           </p>
         </div>
       </section>
@@ -388,12 +386,6 @@
                     <p>
                       Let <var>E</var> be
                       <var>RestrictionTarget</var>.{{RestrictionTarget/[[Element]]}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If <var>E</var> is not a [=valid restriction target=] for [=this=], return a
-                      {{Promise}} [=rejected=] with a new {{InvalidStateError}}.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
Remove the requirement of restriction-target-validity at the time when restrictTo() is called.
* Still check that `this` is restrictable MediaStreamTrack.
* Individual frames will check restriction-target-validity. New frames will not be issued for invalid frames (until validty is restored).