### PR TITLE
Fix interaction with cropTo()

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,6 @@
               <var>T</var>.<a data-cite="mediacapture-streams/#dfn-readystate">readyState</a> is
               <a data-cite="mediacapture-streams/#idl-def-MediaStreamTrackState.live">"live"</a>.
             </li>
-            <li><var>T</var> is not <a data-cite="mediacapture-region#dfn-cropped">cropped</a>.</li>
           </ul>
         </section>
         <section>
@@ -386,6 +385,13 @@
                     <p>
                       Let <var>E</var> be
                       <var>RestrictionTarget</var>.{{RestrictionTarget/[[Element]]}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Update [=this=] video track's
+                      <a data-cite="!mediacapture-region/#dfn-crop-states">crop-state</a>
+                      to <a data-cite="!mediacapture-region/#dfn-uncropped">uncropped</a>.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
Un-specify that MSTs on which restrictTo() is called must not be cropped. Allow restrictTo() and cropTo() to override each other's state.