### PR TITLE
Add citation for stacking context.

### DIFF
--- a/element-capture.js
+++ b/element-capture.js
@@ -1,6 +1,7 @@
 var respecConfig = {
   group: "cg/sccg",
   specStatus: "CG-DRAFT",
+  latestVersion: "https://screen-share.github.io/element-capture/",
   github: {
     repoURL: "https://github.com/screen-share/element-capture/",
     branch: "main",
@@ -25,4 +26,16 @@ var respecConfig = {
     "screen-capture",
   ],
   subjectPrefix: "[element-capture]",
+  localBiblio: {
+    css2ed: {
+      title: "CSS 2 Editor\'s Draft",
+      href: "https://drafts.csswg.org/css2/",
+      editors: [
+        "Sam Sneddon",
+        "Tantek Çelik"
+      ],
+      publisher: "W3C",
+    },
+  },
 };
+

--- a/index.html
+++ b/index.html
@@ -264,16 +264,16 @@
           <h4>Elements eligible for restriction</h4>
           <p>
             We say that an {{Element}} <var>E</var> is <dfn>eligible for restriction</dfn> if and
-            only if it fulfils all of the following conditions:
+            only if it fulfills all of the following conditions:
           </p>
           <ul>
             <li>
-              <p><var>E</var> forms a stacking context.</p>
+              <p><var>E</var> forms a <a data-cite="css2ed#stacking-context">stacking context</a>.</p>
             </li>
             <li>
               <p>
                 <var>E</var> is
-                <a data-cite="css-transforms-2#grouping-property-values">flattened in 3D.</a>
+                <a data-cite="css-transforms-2#grouping-property-values">flattened in 3D</a>.
               </p>
             </li>
             <li>
@@ -531,7 +531,7 @@
         </p>
         <p>
           The mechanisms introduced in this specification allow a responsible application to
-          structure itself in a way that would completely guaratnee that such issues are impossible.
+          structure itself in a way that would completely guarantee that such issues are impossible.
           Such an application can more easily make and keep privacy guarantees to its users.
         </p>
       </section>
@@ -552,7 +552,7 @@
           </p>
         </section>
         <section>
-          <h3>Aggravating old attack vetors</h3>
+          <h3>Aggravating old attack vectors</h3>
           <p>
             The main concern is that the mechanisms we introduce in this specification should not
             <b>aggravate</b> the old attack vectors described above. One naturally worries that the


### PR DESCRIPTION
This PR adds a citation for the concept of `stacking context`, which is defined in CSS 2.
CSS does not export this term to specref so a manual citation is needed.
It also makes a couple of minor spelling corrections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfoltzgoogle/element-capture/pull/40.html" title="Last updated on Jan 10, 2024, 12:22 AM UTC (56bb915)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/element-capture/40/79eeb07...mfoltzgoogle:56bb915.html" title="Last updated on Jan 10, 2024, 12:22 AM UTC (56bb915)">Diff</a>