### PR TITLE
Queue a global task to resolve  a Promise.

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,8 +428,8 @@
                       <var>p</var> when it is guaranteed that no more frames [=restricted=]
                       (or [=unrestricted=]) according to <var>PRE-STATE</var> will be delivered to
                       the application, and that any additional frames delivered to the application
-                      will therefore be [=restricted=] (or [=unrestricted=]) according to
-                      either <var>POST-STATE</var> or a later state.
+                      will therefore be [=restricted=] (or [=unrestricted=]) according to either
+                      <var>POST-STATE</var> or a later state.
                     </p>
                   </li>
                 </ol>

--- a/index.html
+++ b/index.html
@@ -356,6 +356,11 @@
             Promise&lt;undefined&gt; restrictTo(RestrictionTarget? RestrictionTarget);
           };
         </pre>
+        <p>
+            All tasks queued below use the <a data-cite="!HTML#rendering-task-source">rendering
+            task source</a> associated with the same <a data-cite="!HTML#global object">global
+            object</a> as the {{BrowserCaptureMediaStreamTrack}}.
+        </p>
         <dl
           data-link-for="BrowserCaptureMediaStreamTrack"
           data-dfn-for="BrowserCaptureMediaStreamTrack"
@@ -419,11 +424,12 @@
                     <p>
                       Call the track's state before this method invocation <var>PRE-STATE</var>, and
                       after this method invocation <var>POST-STATE</var>. The user agent MUST
-                      resolve <var>p</var> when it is guaranteed that no more frames [=restricted=]
+                      <a data-cite="!HTML#queue-a-global-task">queue a global task</a> to resolve
+                      <var>p</var> when it is guaranteed that no more frames [=restricted=]
                       (or [=unrestricted=]) according to <var>PRE-STATE</var> will be delivered to
                       the application, and that any additional frames delivered to the application
-                      will therefore be [=restricted=] (or [=unrestricted=]) according to either
-                      <var>POST-STATE</var> or a later state.
+                      will therefore be [=restricted=] (or [=unrestricted=]) according to
+                      either <var>POST-STATE</var> or a later state.
                     </p>
                   </li>
                 </ol>


### PR DESCRIPTION
Fixes Issue #43.

Promises can only be resolved (or rejected) on the main event loop.  Queue a global task to do so when the Promise returned by `restrictTo()` resolves.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/markafoltz/element-capture/pull/45.html" title="Last updated on Sep 16, 2024, 9:14 PM UTC (6106a9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/element-capture/45/cb84846...markafoltz:6106a9c.html" title="Last updated on Sep 16, 2024, 9:14 PM UTC (6106a9c)">Diff</a>