### PR TITLE
Define rendering process for restricted elements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,14 +459,10 @@
         </li>
       </ol>
       <p>
-        Let the <dfn>decorated bounding box</dfn> of an element be smallest
-        axis-aligned rectangle that contains
-        the <a data-cite="css-backgrounds-3#border-image-area">border image areas</a> of the
-        element's principal box.
-      <p>
         The frame produced in the final step is constructed by
         rendering <var>E</var> and its descendants over an infinite transparent
-        canvas, positioned so that the edges of the <a>decorated bounding
+        canvas, positioned so that the edges of the
+        <a data-cite="!css-images-4#decorated-bounding-box">decorated bounding
         box</a> are flush with the edges of the frame.
       </p>
       <p class="note">

--- a/index.html
+++ b/index.html
@@ -458,6 +458,31 @@
           to <var>intersection</var>.
         </li>
       </ol>
+      <p>
+        Let the <dfn>decorated bounding box</dfn> of an element be smallest
+        axis-aligned rectangle that contains
+        the <a data-cite="css-backgrounds-3#border-image-area">border image areas</a> of the
+        element's principal box.
+      <p>
+        The frame produced in the final step is constructed by
+        rendering <var>E</var> and its descendants over an infinite transparent
+        canvas, positioned so that the edges of the <a>decorated bounding
+        box</a> are flush with the edges of the frame.
+      </p>
+      <p class="note">
+        In some implementations, the underlying pixel format for the frame data
+        will not be able to carry alpha channel information.  In this case, the
+        implementation can blend the rendered frame with an infinite canvas of black
+        (`rgb(0,0,0)`).
+      </p>
+      <p class="note">
+        Implementations may either re-use existing bitmap data generated
+        for <var>E</var> or regenerate the display of the element to maximize
+        quality at the frame's size (for example, if the implementation detects
+        that the referenced element is an SVG fragment). However, the frame must
+        look identical to <var>E</var> as rendered above, modulo rasterization
+        quality.
+      </p>
     </section>
     <section id="sample-code">
       <h2>Sample Code</h2>


### PR DESCRIPTION
Addresses issues #1 and #2.

This borrows language from the definition of CSS `element()` function to specify a rendering process
for restricted elements and adds relevant implementation notes.

The `element()` function covers additional cases which are not allowed for element capture (like non-rendered elements and paint sources).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/markafoltz/element-capture/pull/46.html" title="Last updated on Sep 16, 2024, 9:12 PM UTC (07f4b85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/element-capture/46/cb84846...markafoltz:07f4b85.html" title="Last updated on Sep 16, 2024, 9:12 PM UTC (07f4b85)">Diff</a>