### PR TITLE
Make only [[Restrictable]] tracks restrictable

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,6 +241,8 @@
             conditions:
           </p>
           <ul>
+            <!-- TODO: Use spec-linking after merging https://github.com/w3c/mediacapture-main/pull/1015. -->
+            <li><var>T</var>.<code>[[\Restrictable]]</code> is <code>true</code>.</li>
             <li>
               <var>T</var> is associated with a
               <a data-cite="screen-capture/#dfn-browser">browser</a>


### PR DESCRIPTION
Only tracks received via a method that sets `[[Restrictable]]` to `true` are eligible for restriction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/element-capture/pull/49.html" title="Last updated on Sep 26, 2024, 10:59 PM UTC (f467cd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/element-capture/49/347e75d...eladalon1983:f467cd0.html" title="Last updated on Sep 26, 2024, 10:59 PM UTC (f467cd0)">Diff</a>